### PR TITLE
Fix raw github URLs in Grafana for automated pulling of newer dashboard configuration

### DIFF
--- a/dashboards/k8s-build/bin/build.py
+++ b/dashboards/k8s-build/bin/build.py
@@ -45,7 +45,7 @@ with open(dashboard_template_path, "r") as template_file:
         k8s_dashboard = deepcopy(k8s_template)
         k8s_dashboard["metadata"]["name"] = os.path.splitext(os.path.basename(json_dashboard))[0]
         k8s_dashboard["spec"]["name"] = os.path.basename(json_dashboard)
-        k8s_dashboard["spec"]["url"] = f"https://raw.githubusercontent.com/datastax/metrics-collector-for=apache-cassandra/master/dashboards/grafana/generated-dashboards/{os.path.basename(json_dashboard)}"
+        k8s_dashboard["spec"]["url"] = f"https://raw.githubusercontent.com/datastax/metric-collector-for-apache-cassandra/master/dashboards/grafana/generated-dashboards/{os.path.basename(json_dashboard)}"
 
         # Read in JSON dashboard
         with open(json_dashboard, "r") as json_file:

--- a/dashboards/k8s-build/generated/grafana/cassandra-condensed.dashboard.yaml
+++ b/dashboards/k8s-build/generated/grafana/cassandra-condensed.dashboard.yaml
@@ -812,4 +812,4 @@ spec:
     \   },\n   \"timezone\": \"browser\",\n   \"title\": \"Cassandra Cluster Condensed\"\
     ,\n   \"version\": 0\n}\n"
   name: cassandra-condensed.json
-  url: https://raw.githubusercontent.com/datastax/metrics-collector-for=apache-cassandra/master/dashboards/grafana/generated-dashboards/cassandra-condensed.json
+  url: https://raw.githubusercontent.com/datastax/metric-collector-for-apache-cassandra/master/dashboards/grafana/generated-dashboards/cassandra-condensed.json

--- a/dashboards/k8s-build/generated/grafana/system-metrics.dashboard.yaml
+++ b/dashboards/k8s-build/generated/grafana/system-metrics.dashboard.yaml
@@ -3515,4 +3515,4 @@ spec:
        "version": 0
     }
   name: system-metrics.json
-  url: https://raw.githubusercontent.com/datastax/metrics-collector-for=apache-cassandra/master/dashboards/grafana/generated-dashboards/system-metrics.json
+  url: https://raw.githubusercontent.com/datastax/metric-collector-for-apache-cassandra/master/dashboards/grafana/generated-dashboards/system-metrics.json

--- a/dashboards/k8s-build/templates/grafana/dashboard.yaml
+++ b/dashboards/k8s-build/templates/grafana/dashboard.yaml
@@ -5,6 +5,6 @@ metadata:
     app: grafana
   name: empty
 spec:
-  url: https://raw.githubusercontent.com/datastax/dse-metric-reporter-dashboards/master/grafana/dashboards/dashboard.json
+  url: https://raw.githubusercontent.com/datastax/metric-collector-for-apache-cassandra/master/dashboards/grafana/generated-dashboards/dashboard.yaml
   json: "{}"
   name: empty.json

--- a/dashboards/k8s-build/templates/grafana/dashboard.yaml
+++ b/dashboards/k8s-build/templates/grafana/dashboard.yaml
@@ -5,6 +5,6 @@ metadata:
     app: grafana
   name: empty
 spec:
-  url: https://raw.githubusercontent.com/datastax/metric-collector-for-apache-cassandra/master/dashboards/grafana/generated-dashboards/dashboard.yaml
+  url: ""
   json: "{}"
   name: empty.json


### PR DESCRIPTION
Invalid URLs in the generated dashboard resources resulted in 404. This did not inhibit the deployment of the dashboards as the content is included as well. Now that the URLs are fixed, the installation of a dashboard on Grafana will automatically check for a newer version.