### PR TITLE
improve dashboards according to feedbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,28 +9,28 @@ Metric collection and Dashboards for Apache Cassandra (2.2, 3.0, 3.11, 4.0) clus
 ## Introduction
 
    Metric Collector for Apache Cassandra (MCAC) aggregates OS and C* metrics along with diagnostic events
-   to facilitate problem resolution and remediation. 
+   to facilitate problem resolution and remediation.
    It supports existing Apache Cassandra clusters and is a self contained drop in agent.
 
-   * Built on [collectd](https://collectd.org), a popular, well-supported, open source metric collection agent. 
-   With over 90 plugins, you can tailor the solution to collect metrics most important to you and ship them to 
-   wherever you need. 
-   
-   * Easily added to Cassandra nodes as a java agent, Apache Cassandra sends metrics and other structured events 
+   * Built on [collectd](https://collectd.org), a popular, well-supported, open source metric collection agent.
+   With over 90 plugins, you can tailor the solution to collect metrics most important to you and ship them to
+   wherever you need.
+
+   * Easily added to Cassandra nodes as a java agent, Apache Cassandra sends metrics and other structured events
    to collectd over a local unix socket.  
-   
-   * Fast and efficient.  It can track over 100k unique metric series per node (i.e. hundreds of tables). 
-     
+
+   * Fast and efficient.  It can track over 100k unique metric series per node (i.e. hundreds of tables).
+
    * Comes with extensive dashboards out of the box, built on [prometheus](http://prometheus.io) and [grafana](http://grafana.com).  
      The Cassandra dashboards let you aggregate latency accurately across all nodes, dc or rack, down to an individual table.   
-     
+
      ![](.screenshots/overview.png)    
      ![](.screenshots/os.png)
      ![](.screenshots/cluster.png)
-   
+
 ## Design Principles
 
-  * Little/No performance impact to C* 
+  * Little/No performance impact to C*
   * Simple to install and self managed
   * Collect all OS and C* metrics by default
   * Keep historical metrics on node for analysis
@@ -39,76 +39,81 @@ Metric collection and Dashboards for Apache Cassandra (2.2, 3.0, 3.11, 4.0) clus
 ## Try the demo
 `docker-compose up` is all you need from the [dashboards/demo](dashboards/demo) directory to get a cluster with a light
 workload and dashboards connected to kick the tires.
-      
+
 ## Installation of Agent
-    
+
  1. Download the [latest release](https://github.com/datastax/metric-collector-for-apache-cassandra/releases/latest) of the agent onto your Cassandra nodes.
- The archive is self contained so no need do anything other than `tar -zxf latest.tar.gz` 
+ The archive is self contained so no need do anything other than `tar -zxf latest.tar.gz`
  into any location you prefer like `/usr/local` or `/opt`.
 
  2. Add the following line into the `cassandra-env.sh` file:
-     
+
      ````
-     MCAC_ROOT=/path/to/directory 
+     MCAC_ROOT=/path/to/directory
      JVM_OPTS="$JVM_OPTS -javaagent:${MCAC_ROOT}/lib/datastax-mcac-agent.jar"
      ````
  3. Bounce the node.  
- 
- On restart you should see `'Starting DataStax Metric Collector for Apache Cassandra'` in the Cassandra system.log 
+
+ On restart you should see `'Starting DataStax Metric Collector for Apache Cassandra'` in the Cassandra system.log
  and the prometheus exporter will be available on port `9103`
- 
+
  The [config/metric-collector.yaml](config/metric-collector.yaml) file requires no changes by default but please read and add any customizations like
- filtering of metrics you don't need. 
- 
+ filtering of metrics you don't need.
+
  The [config/collectd.conf.tmpl](config/collectd.conf.tmpl) file can also be edited to change default collectd plugins enabled.  But it's recommended
- you use the [include path pattern](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#include_path_pattern) 
+ you use the [include path pattern](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#include_path_pattern)
  to configure extra plugins.
 
 ## Installing the Prometheus Dashboards
 
  1. Download the [latest release](https://github.com/datastax/metric-collector-for-apache-cassandra/releases/latest) of the dashboards and unzip.
- 
+
  2. Install [Docker compose](https://docs.docker.com/compose/install/)
- 
+
  3. Add the list of C* nodes with running agents to [tg_mcac.json](dashboards/prometheus/tg_mcac.json)
-  
+
  4. `docker-compose up` will start everything and begin collection of metrics
 
  5. The Grafana web ui runs on port `3000` and the prometheus web ui runs on port `9090`
-     
+
  If you have an existing prometheus setup you will need the dashboards and [relabel config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) from the
  included [prometheus.yaml](dashboards/prometheus/prometheus.yaml) file.
 
+## Cassandra version supported:
+
+The supported versions of Apache Cassandra: 2.2+ (2.2.X, 3.0.X, 3.11.X)
+Apache Cassandra 4.0 breaks compatibility. The support for this version is being worked on as we will definitely support it as well.
+
 ## Kubernetes Support
 Check out the [dashboards/k8s-build](dashboards/k8s-build) directory for a guide on using this project along with Kubernetes.
- 
+
 ## FAQ
   1. Where is the list of all Cassandra metrics?
-  
+
      The full list is located on [Apache Cassandra docs](https://cassandra.apache.org/doc/latest/operating/metrics.html) site.
      The names are automatically changed from CamelCase to snake_case.
-  
-     In the case of prometheus the metrics are further renamed based on [relabel config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) which live in the 
+
+     In the case of prometheus the metrics are further renamed based on [relabel config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) which live in the
      [prometheus.yaml](dashboards/prometheus/prometheus.yaml) file.
-  
+
   2. How can I filter out metrics I don't care about?
-     
+
      Please read the [metric-collector.yaml](config/metric-collector.yaml) section on how to add filtering rules.
-  
+
   3. What is the datalog? and what is it for?
-      
+
      The datalog is a space limited JSON based structured log of metrics and events which are optionally kept on each node.  
      It can be useful to diagnose issues that come up with your cluster.  If you wish to use the logs yourself
-     there's a [script](scripts/datalog-parser.py) included to parse these logs which can be analyzed or piped 
+     there's a [script](scripts/datalog-parser.py) included to parse these logs which can be analyzed or piped
      into [jq](https://stedolan.github.io/jq/).
-     
-     Alternatively, DataStax offers free support for issues as part of our [keep calm](https://www.datastax.com/keepcalm) 
+
+     Alternatively, DataStax offers free support for issues as part of our [keep calm](https://www.datastax.com/keepcalm)
      initiative and these logs can help our support engineers help diagnose your problem.
-     
+
   4. Will the MCAC agent work on a Mac?
-     
+
      No. It can be made to but it's currently only supported on Linux based OS.
-          
+
 ## License
 
 Copyright DataStax, Inc.
@@ -118,4 +123,3 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-

--- a/config/collectd.conf.tmpl
+++ b/config/collectd.conf.tmpl
@@ -89,13 +89,6 @@ LoadPlugin tcpconns
 LoadPlugin match_regex
 LoadPlugin target_set
 LoadPlugin target_replace
-LoadPlugin ntpd
-
-<Plugin "ntpd">
-  Host "{{hostName}}"
-  Port "123"
-  ReverseLookups false
-</Plugin>
 
 PreCacheChain "PreCache"
 <Chain "PreCache">

--- a/dashboards/demo/docker-compose.yml
+++ b/dashboards/demo/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - demo_net
     environment:
       - "TLP_STRESS_CASSANDRA_HOST=cassandra"
-    command: "run KeyValue --rate 100 -d 1d -r .8"
+    command: "run KeyValue --rate 30 -d 1d -r .8"
     depends_on:
       cassandra2:
         condition: service_healthy
@@ -102,7 +102,7 @@ services:
       - demo_net
     environment:
       - "TLP_STRESS_CASSANDRA_HOST=cassandra"
-    command: "run BasicTimeSeries --rate 100 -d 1d -r .9"
+    command: "run BasicTimeSeries --rate 20 -d 1d -r .9"
     depends_on:
       cassandra2:
         condition: service_healthy

--- a/dashboards/grafana/dashboards-jsonnet/cassandra-condensed.jsonnet
+++ b/dashboards/grafana/dashboards-jsonnet/cassandra-condensed.jsonnet
@@ -19,8 +19,9 @@ dashboard.new(
   'Cassandra Cluster Condensed',
   description='Single pane of glass for most important Cassandra metrics',
   schemaVersion=14,
+  refresh='30s',
   time_from='now-30m',
-  refresh='1m',
+  editable=true,
   tags=['os'],
   style='dark'
 )
@@ -337,7 +338,7 @@ dashboard.new(
     )
     .addSeriesOverride({
       "alias": "/.*Connected/",
-      "yaxis": 2 
+      "yaxis": 2
     })
     .addTarget(
       prometheus.target(
@@ -369,7 +370,7 @@ dashboard.new(
           legendFormat="$by:{{$by}} {{$latency}} {{request_type}}"
       )
     )
-  ) 
+  )
   .addPanel(
     graphpanel.new(
       title="Memtable Space $keyspace.$table / $by",
@@ -493,7 +494,7 @@ dashboard.new(
           legendFormat="$by:{{$by}} Coordinator Range Scan"
       )
     )
-  ) 
+  )
   .addPanel(
     graphpanel.new(
       title="Streaming / $by / $rate",
@@ -517,5 +518,5 @@ dashboard.new(
           legendFormat="{{$by}}: Outgoing Stream"
       )
     )
-  ) 
+  )
 )

--- a/dashboards/grafana/dashboards-jsonnet/overview.jsonnet
+++ b/dashboards/grafana/dashboards-jsonnet/overview.jsonnet
@@ -44,10 +44,11 @@ local reversedColors =[
 dashboard.new(
   'Cassandra Overview',
   schemaVersion=14,
-  refresh='1m',
-  time_from='now-15m',
+  refresh='30s',
+  time_from='now-30m',
   editable=true,
   tags=['Cassandra', 'Overview'],
+  style='dark'
 )
 .addTemplate(
   grafana.template.datasource(
@@ -132,7 +133,7 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        expr='sum by (cluster, request_type) (irate(' + prefix + '_client_request_latency_total{cluster=~"$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        expr='sum by (cluster, request_type) (rate(' + prefix + '_client_request_latency_total{cluster=~"$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='{{request_type}}',
       )
     )
@@ -322,7 +323,7 @@ dashboard.new(
     .addTarget(
       prometheus.target(
         # In scope!~"Write|Read|.*-.*", we want to exclude charts above and all the per-consistency_level info like "Read-LOCAL_ONE"
-        expr='histogram_quantile(0.99, sum(irate(' + prefix + '_client_request_latency_bucket{cluster=~"$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node", request_type!~"write|read|.*-.*"}[5m])) by (le, request_type, cluster))',
+        expr='histogram_quantile(0.99, sum(rate(' + prefix + '_client_request_latency_bucket{cluster=~"$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node", request_type!~"write|read|.*-.*"}[1m])) by (le, request_type, cluster))',
         legendFormat='p99 {{request_type}}'
       )
     )
@@ -338,6 +339,7 @@ dashboard.new(
       transparent=true,
       span=12,
       global_unit_format='none',
+      global_operator_name='current',
       global_thresholds=[
         {
           "value": 0,
@@ -350,7 +352,6 @@ dashboard.new(
           "color": "#299c46"
         }
       ],
-      global_operator_name='current',
     )
     .addTarget(
       prometheus.target(
@@ -667,7 +668,7 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        expr='sum by (cluster, pool_name) (' + prefix + '_thread_pools_total_blocked_tasks_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"})',
+        expr='sum by (cluster, pool_name) (irate(' + prefix + '_thread_pools_total_blocked_tasks_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
         legendFormat='{{cluster}} - blocked {{pool_name}}',
       )
     )
@@ -691,7 +692,7 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        expr='sum by (cluster, message_type) (' + prefix + '_dropped_message_dropped_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"})',
+        expr='sum by (cluster, message_type) (irate(' + prefix + '_dropped_message_dropped_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
         legendFormat='{{cluster}} - dropped {{message_type}}',
       )
     )
@@ -769,19 +770,19 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        expr='max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{type="idle", cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))))',
+        expr='max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{type="idle", cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))))',
         legendFormat='max',
       )
     )
     .addTarget(
       prometheus.target(
-        expr='min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{type="idle", cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))))',
+        expr='min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{type="idle", cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))))',
         legendFormat='min',
       )
     )
     .addTarget(
       prometheus.target(
-        expr='avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{type="idle", cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))))',
+        expr='avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{type="idle", cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))))',
         legendFormat='avg',
       )
     )
@@ -873,19 +874,19 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        expr='max by (cluster) (irate(collectd_processes_disk_octets_read_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        expr='max by (cluster) (rate(collectd_processes_disk_octets_read_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='max',
       )
     )
     .addTarget(
       prometheus.target(
-        'min by (cluster) (irate(collectd_processes_disk_octets_read_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'min by (cluster) (rate(collectd_processes_disk_octets_read_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='min',
       )
     )
     .addTarget(
       prometheus.target(
-        'avg by (cluster) (irate(collectd_processes_disk_octets_read_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'avg by (cluster) (rate(collectd_processes_disk_octets_read_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='avg',
       )
     )
@@ -910,19 +911,19 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        expr='max by (cluster) (irate(collectd_processes_disk_octets_write_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        expr='max by (cluster) (rate(collectd_processes_disk_octets_write_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='max',
       )
     )
     .addTarget(
       prometheus.target(
-        'min by (cluster) (irate(collectd_processes_disk_octets_write_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'min by (cluster) (rate(collectd_processes_disk_octets_write_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='min',
       )
     )
     .addTarget(
       prometheus.target(
-        'avg by (cluster) (irate(collectd_processes_disk_octets_write_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'avg by (cluster) (rate(collectd_processes_disk_octets_write_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='avg',
       )
     )
@@ -948,13 +949,13 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        'sum by (cluster) (irate(collectd_interface_if_octets_rx_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'sum by (cluster) (rate(collectd_interface_if_octets_rx_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='outgoing',
       )
     )
     .addTarget(
       prometheus.target(
-        'sum by (cluster) (irate(collectd_interface_if_octets_rx_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'sum by (cluster) (rate(collectd_interface_if_octets_rx_total{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='incoming',
       )
     )
@@ -983,22 +984,24 @@ dashboard.new(
       legend_sortDesc=true,
       shared_tooltip=false,
       decimals=2,
+      min=0,
+      max=1,
     )
     .addTarget(
       prometheus.target(
-        'max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / 1000))',
+        'max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m])) / 1000))',
         legendFormat='max',
       )
     )
     .addTarget(
       prometheus.target(
-        'min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / 1000))',
+        'min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m])) / 1000))',
         legendFormat='min',
       )
     )
     .addTarget(
       prometheus.target(
-        'avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m])) / 1000))',
+        'avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m])) / 1000))',
         legendFormat='avg',
       )
     )
@@ -1023,19 +1026,19 @@ dashboard.new(
     )
     .addTarget(
       prometheus.target(
-        'max by (cluster) (irate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'max by (cluster) (rate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='max',
       )
     )
     .addTarget(
       prometheus.target(
-        'min by (cluster) (irate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'min by (cluster) (rate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='min',
       )
     )
     .addTarget(
       prometheus.target(
-        'avg by (cluster) (irate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[1m]))',
+        'avg by (cluster) (rate(' + prefix + '_jvm_gc_time{cluster="$cluster", dc=~"$dc", rack=~"$rack", instance=~"$node"}[5m:1m]))',
         legendFormat='avg',
       )
     )

--- a/dashboards/grafana/dashboards-jsonnet/overview.jsonnet
+++ b/dashboards/grafana/dashboards-jsonnet/overview.jsonnet
@@ -352,6 +352,20 @@ dashboard.new(
           "color": "#299c46"
         }
       ],
+      range_maps=[
+        {
+          "from": "0",
+          "to": "0.9999",
+          "text": "DOWN"
+        },
+        {
+          "from": "1",
+          "to": "1",
+          "text": "UP"
+        }
+      ],
+      mapping_type=2,
+      value_enabled=true,
     )
     .addTarget(
       prometheus.target(

--- a/dashboards/grafana/generated-dashboards/cassandra-condensed.json
+++ b/dashboards/grafana/generated-dashboards/cassandra-condensed.json
@@ -5,13 +5,13 @@
       "list": [ ]
    },
    "description": "Single pane of glass for most important Cassandra metrics",
-   "editable": false,
+   "editable": true,
    "gnetId": null,
    "graphTooltip": 0,
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "1m",
+   "refresh": "30s",
    "rows": [
       {
          "collapse": false,

--- a/dashboards/grafana/generated-dashboards/cassandra-condensed.json
+++ b/dashboards/grafana/generated-dashboards/cassandra-condensed.json
@@ -838,6 +838,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "(no keyspace/table filters apply)",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 13,
                "legend": {
@@ -850,6 +851,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -932,6 +934,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "(no keyspace/table filters apply)",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 14,
                "legend": {
@@ -944,6 +947,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1013,6 +1017,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 15,
                "legend": {
@@ -1025,6 +1030,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1123,6 +1129,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 16,
                "legend": {
@@ -1135,6 +1142,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1227,6 +1235,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 17,
                "legend": {
@@ -1239,6 +1248,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1337,6 +1347,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 18,
                "legend": {
@@ -1349,6 +1360,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },

--- a/dashboards/grafana/generated-dashboards/overview.json
+++ b/dashboards/grafana/generated-dashboards/overview.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "1m",
+   "refresh": "30s",
    "rows": [
       {
          "collapse": false,
@@ -98,7 +98,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (cluster, request_type) (irate(mcac_client_request_latency_total{cluster=~\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "sum by (cluster, request_type) (rate(mcac_client_request_latency_total{cluster=~\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{request_type}}",
@@ -589,7 +589,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(irate(mcac_client_request_latency_bucket{cluster=~\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\", request_type!~\"write|read|.*-.*\"}[5m])) by (le, request_type, cluster))",
+                     "expr": "histogram_quantile(0.99, sum(rate(mcac_client_request_latency_bucket{cluster=~\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\", request_type!~\"write|read|.*-.*\"}[1m])) by (le, request_type, cluster))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "p99 {{request_type}}",
@@ -1452,7 +1452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (cluster, pool_name) (mcac_thread_pools_total_blocked_tasks_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"})",
+                     "expr": "sum by (cluster, pool_name) (irate(mcac_thread_pools_total_blocked_tasks_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster}} - blocked {{pool_name}}",
@@ -1534,7 +1534,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (cluster, message_type) (mcac_dropped_message_dropped_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"})",
+                     "expr": "sum by (cluster, message_type) (irate(mcac_dropped_message_dropped_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster}} - dropped {{message_type}}",
@@ -1804,21 +1804,21 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{type=\"idle\", cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))))",
+                     "expr": "max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{type=\"idle\", cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "max",
                      "refId": "A"
                   },
                   {
-                     "expr": "min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{type=\"idle\", cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))))",
+                     "expr": "min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{type=\"idle\", cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "min",
                      "refId": "B"
                   },
                   {
-                     "expr": "avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{type=\"idle\", cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / sum by (cluster, dc, rack, instance) (irate(collectd_cpu_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))))",
+                     "expr": "avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{type=\"idle\", cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / sum by (cluster, dc, rack, instance) (rate(collectd_cpu_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "avg",
@@ -2107,21 +2107,21 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "max by (cluster) (irate(collectd_processes_disk_octets_read_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "max by (cluster) (rate(collectd_processes_disk_octets_read_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "max",
                      "refId": "A"
                   },
                   {
-                     "expr": "min by (cluster) (irate(collectd_processes_disk_octets_read_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "min by (cluster) (rate(collectd_processes_disk_octets_read_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "min",
                      "refId": "B"
                   },
                   {
-                     "expr": "avg by (cluster) (irate(collectd_processes_disk_octets_read_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "avg by (cluster) (rate(collectd_processes_disk_octets_read_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "avg",
@@ -2213,21 +2213,21 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "max by (cluster) (irate(collectd_processes_disk_octets_write_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "max by (cluster) (rate(collectd_processes_disk_octets_write_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "max",
                      "refId": "A"
                   },
                   {
-                     "expr": "min by (cluster) (irate(collectd_processes_disk_octets_write_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "min by (cluster) (rate(collectd_processes_disk_octets_write_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "min",
                      "refId": "B"
                   },
                   {
-                     "expr": "avg by (cluster) (irate(collectd_processes_disk_octets_write_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "avg by (cluster) (rate(collectd_processes_disk_octets_write_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "avg",
@@ -2314,14 +2314,14 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (cluster) (irate(collectd_interface_if_octets_rx_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "sum by (cluster) (rate(collectd_interface_if_octets_rx_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "outgoing",
                      "refId": "A"
                   },
                   {
-                     "expr": "sum by (cluster) (irate(collectd_interface_if_octets_rx_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "sum by (cluster) (rate(collectd_interface_if_octets_rx_total{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "incoming",
@@ -2427,21 +2427,21 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / 1000))",
+                     "expr": "max by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m])) / 1000))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "max",
                      "refId": "A"
                   },
                   {
-                     "expr": "min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / 1000))",
+                     "expr": "min by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m])) / 1000))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "min",
                      "refId": "B"
                   },
                   {
-                     "expr": "avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (irate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m])) / 1000))",
+                     "expr": "avg by (cluster) (1 - (sum by (cluster, dc, rack, instance) (rate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m])) / 1000))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "avg",
@@ -2472,8 +2472,8 @@
                      "format": "percentunit",
                      "label": null,
                      "logBase": 1,
-                     "max": null,
-                     "min": null,
+                     "max": 100,
+                     "min": 0,
                      "show": true
                   },
                   {
@@ -2481,8 +2481,8 @@
                      "format": "percentunit",
                      "label": null,
                      "logBase": 1,
-                     "max": null,
-                     "min": null,
+                     "max": 100,
+                     "min": 0,
                      "show": true
                   }
                ]
@@ -2535,21 +2535,21 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "max by (cluster) (irate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "max by (cluster) (rate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "max",
                      "refId": "A"
                   },
                   {
-                     "expr": "min by (cluster) (irate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "min by (cluster) (rate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "min",
                      "refId": "B"
                   },
                   {
-                     "expr": "avg by (cluster) (irate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[1m]))",
+                     "expr": "avg by (cluster) (rate(mcac_jvm_gc_time{cluster=\"$cluster\", dc=~\"$dc\", rack=~\"$rack\", instance=~\"$node\"}[5m:1m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "avg",
@@ -2821,7 +2821,7 @@
       ]
    },
    "time": {
-      "from": "now-15m",
+      "from": "now-30m",
       "to": "now"
    },
    "timepicker": {

--- a/dashboards/grafana/generated-dashboards/overview.json
+++ b/dashboards/grafana/generated-dashboards/overview.json
@@ -68,6 +68,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Total Requests Per Cluster, by Request Type",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 5,
                "legend": {
@@ -78,6 +79,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -150,6 +152,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Total Timeouts, Failures, Unavailable Rates for each cluster",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 6,
                "legend": {
@@ -160,6 +163,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -347,6 +351,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Read latency for coordinated reads",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 8,
                "legend": {
@@ -357,6 +362,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -453,6 +459,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Write latency for coordinated writes",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 9,
                "legend": {
@@ -463,6 +470,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -559,6 +567,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Other p99 latencies for coordinated requests",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 10,
                "legend": {
@@ -569,6 +578,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -651,6 +661,17 @@
                "description": "Nodes Status uses Internal/Gossip activity. Be mindful that if Native or Thrift protocol are disabled, the nodes won't be reachable, and still marked up",
                "gridPos": { },
                "id": 11,
+               "mappingType": 2,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
                "polystat": {
                   "globalOperatorName": "current",
                   "globalThresholds": [
@@ -665,8 +686,21 @@
                         "value": 1
                      }
                   ],
-                  "globalUnitFormat": "none"
+                  "globalUnitFormat": "none",
+                  "valueEnabled": true
                },
+               "rangeMaps": [
+                  {
+                     "from": "0",
+                     "text": "DOWN",
+                     "to": "0.9999"
+                  },
+                  {
+                     "from": "1",
+                     "text": "UP",
+                     "to": "1"
+                  }
+               ],
                "span": 12,
                "targets": [
                   {
@@ -771,6 +805,7 @@
                "decimals": 0,
                "description": "Nodes up and down in the cluster per protocol/activity",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 13,
                "legend": {
@@ -781,6 +816,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": false,
                   "total": false,
@@ -886,6 +922,7 @@
                "description": "Disk space used ordered (fullest disks first)",
                "gridPos": { },
                "id": 14,
+               "links": [ ],
                "sort": {
                   "col": 1,
                   "desc": true
@@ -955,6 +992,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Total sizes of the data on distinct nodes",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 15,
                "legend": {
@@ -965,6 +1003,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1044,6 +1083,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "SSTable Count Max and Average per table",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 16,
                "legend": {
@@ -1054,6 +1094,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1134,6 +1175,7 @@
                "decimals": 0,
                "description": "Maximum pending compactions on any node in the cluster",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 17,
                "legend": {
@@ -1144,6 +1186,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1243,6 +1286,7 @@
                "decimals": 0,
                "description": "Maximum pending compactions per table",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 18,
                "legend": {
@@ -1253,6 +1297,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1340,6 +1385,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Cluster wide pending threads, by thread pool name",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 19,
                "legend": {
@@ -1350,6 +1396,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1422,6 +1469,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Cluster wide blocked threads, by thread pool name",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 20,
                "legend": {
@@ -1432,6 +1480,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1504,6 +1553,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Dropped messages rate summed by message type and cluster",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 21,
                "legend": {
@@ -1514,6 +1564,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1586,6 +1637,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "active threads summed per cluster",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 22,
                "legend": {
@@ -1596,6 +1648,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1668,6 +1721,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Sum of hints being handed off per cluster.",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 23,
                "legend": {
@@ -1678,6 +1732,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1764,6 +1819,7 @@
                "decimals": 1,
                "description": "Maximum CPU utilisation (max 100%)",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 24,
                "legend": {
@@ -1774,6 +1830,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1872,6 +1929,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Max Unix load on a node for a cluster",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 25,
                "legend": {
@@ -1882,6 +1940,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -1978,6 +2037,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Maximum Memory allocated per usage (worst node) - excludes caches, buffers, etc",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 26,
                "legend": {
@@ -1988,6 +2048,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -2067,6 +2128,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Disk read throughput",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 27,
                "legend": {
@@ -2077,6 +2139,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -2173,6 +2236,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Disk write throughput",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 28,
                "legend": {
@@ -2183,6 +2247,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -2279,6 +2344,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Network In and Out per cluster",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 29,
                "legend": {
@@ -2289,6 +2355,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -2387,6 +2454,7 @@
                "decimals": 2,
                "description": "Percentage of the time the node is *not* doing a GC, thus Cassandra is not stopped for GC",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 30,
                "legend": {
@@ -2397,6 +2465,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -2472,7 +2541,7 @@
                      "format": "percentunit",
                      "label": null,
                      "logBase": 1,
-                     "max": 100,
+                     "max": 1,
                      "min": 0,
                      "show": true
                   },
@@ -2481,7 +2550,7 @@
                      "format": "percentunit",
                      "label": null,
                      "logBase": 1,
-                     "max": 100,
+                     "max": 1,
                      "min": 0,
                      "show": true
                   }
@@ -2495,6 +2564,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Garbage collection duration",
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 31,
                "legend": {
@@ -2505,6 +2575,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,
@@ -2601,6 +2672,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Maximum JVM Heap Memory size (worst node) and minimum available heap size",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 32,
                "legend": {
@@ -2611,6 +2683,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "sort": "current",
                   "sortDesc": true,
                   "total": false,

--- a/dashboards/grafana/generated-dashboards/system-metrics.json
+++ b/dashboards/grafana/generated-dashboards/system-metrics.json
@@ -1007,6 +1007,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 15,
                "legend": {
@@ -1017,6 +1018,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1121,6 +1123,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 16,
                "legend": {
@@ -1131,6 +1134,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1243,6 +1247,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Basic network info per interface",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 17,
                "legend": {
@@ -1253,6 +1258,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1335,6 +1341,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Basic network info per interface",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 18,
                "legend": {
@@ -1345,6 +1352,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1427,6 +1435,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Disk Activity / Second",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 19,
                "legend": {
@@ -1439,6 +1448,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1521,6 +1531,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Disk iops per disk",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 20,
                "legend": {
@@ -1533,6 +1544,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1615,6 +1627,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Disk space used",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 21,
                "legend": {
@@ -1627,6 +1640,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1697,6 +1711,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "The amount of requests pending in the disk queue",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 22,
                "legend": {
@@ -1709,6 +1724,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1779,6 +1795,7 @@
                "datasource": "$PROMETHEUS_DS",
                "description": "Disk access times",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 23,
                "legend": {
@@ -1791,6 +1808,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1886,6 +1904,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 24,
                "legend": {
@@ -1896,6 +1915,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -1965,6 +1985,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 25,
                "legend": {
@@ -1975,6 +1996,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2044,6 +2066,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 26,
                "legend": {
@@ -2054,6 +2077,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2123,6 +2147,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 27,
                "legend": {
@@ -2133,6 +2158,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2202,6 +2228,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 28,
                "legend": {
@@ -2212,6 +2239,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2295,6 +2323,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 29,
                "legend": {
@@ -2305,6 +2334,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2374,6 +2404,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 30,
                "legend": {
@@ -2386,6 +2417,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2455,6 +2487,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 31,
                "legend": {
@@ -2467,6 +2500,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2536,6 +2570,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 32,
                "legend": {
@@ -2548,6 +2583,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2617,6 +2653,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 33,
                "legend": {
@@ -2629,6 +2666,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2698,6 +2736,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 34,
                "legend": {
@@ -2710,6 +2749,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2779,6 +2819,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 35,
                "legend": {
@@ -2791,6 +2832,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2888,6 +2930,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 36,
                "legend": {
@@ -2900,6 +2943,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -2969,6 +3013,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 37,
                "legend": {
@@ -2981,6 +3026,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },
@@ -3312,6 +3358,7 @@
                "dashes": false,
                "datasource": "$PROMETHEUS_DS",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 41,
                "legend": {
@@ -3324,6 +3371,7 @@
                   "min": false,
                   "rightSide": false,
                   "show": true,
+                  "sideWidth": null,
                   "total": false,
                   "values": false
                },

--- a/dashboards/grafana/make-dashboards.sh
+++ b/dashboards/grafana/make-dashboards.sh
@@ -6,5 +6,5 @@ cd $DIR
 for file in dashboards-jsonnet/*; do
   name=$(basename $file);
   echo "Generating ${name%.jsonnet}.json"
-  docker run -v `pwd`:/here datastax/grafonnet-lib:v0.1.1 jsonnet --ext-str prefix=mcac /here/$file > `pwd`/generated-dashboards/${name%.jsonnet}.json;
+  docker run -v `pwd`:/here datastax/grafonnet-lib:v0.1.3 jsonnet --ext-str prefix=mcac /here/$file > `pwd`/generated-dashboards/${name%.jsonnet}.json;
 done


### PR DESCRIPTION
* Remove NTP settings in collectd (fails with Chrony - default in RHEL...)
* Change stress setting to be able not to overwhelm Cassandra demo nodes (the idea was to see a straight line in terms of requests to fix rates/irates)
* Add mention of supported C* versions to the readme
* Fix Overview dashboards (add missing rate for dropped messages, also change irate --> rate where relevant and the duration/resolution of rates)
* Make dashboards editable
* Update grafonnet-lib docker image to the current latest
* Use UP/DOWN for node status instead of 1/0.