### PR TITLE
Cassandra version is configurable

### DIFF
--- a/make_package.sh
+++ b/make_package.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 
+# Package version. Mandatory.
 VERSION=$1
+# Cassandra version to use for compilation, e.g. 3.11.10. Optional.
+CASSANDRA_VERSION=$2
+# Compilation profile for this package, look into pom.xml for profile list. Optional.
+BUILD_PROFILE=$3
 
 if [ "$VERSION" == "" ]; then
   echo "Missing version arg"
   exit 1
+fi
+
+OPTIONAL_MVN_ARGS=""
+if [ -n "$CASSANDRA_VERSION" ]; then
+  OPTIONAL_MVN_ARGS="${OPTIONAL_MVN_ARGS} -Dcassandra.version=${CASSANDRA_VERSION}"
+fi
+if [ -n "$BUILD_PROFILE" ]; then
+  OPTIONAL_MVN_ARGS="${OPTIONAL_MVN_ARGS} --activate-profiles=${BUILD_PROFILE}"
 fi
 
 PACKAGE_DIR=package-$VERSION
@@ -12,7 +25,7 @@ PROJECT_DIR_NAME=datastax-mcac-agent-$VERSION
 
 mkdir $PACKAGE_DIR
 
-mvn -DskipTests clean package -Drevision=$VERSION
+mvn -DskipTests clean package -Drevision=$VERSION $OPTIONAL_MVN_ARGS
 mkdir -p $PACKAGE_DIR/$PROJECT_DIR_NAME/config
 cp config/collectd.conf.tmpl $PACKAGE_DIR/$PROJECT_DIR_NAME/config
 cp config/metric-collector.yaml $PACKAGE_DIR/$PROJECT_DIR_NAME/config

--- a/pom.xml
+++ b/pom.xml
@@ -37,22 +37,6 @@
             <version>${mustache.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.cassandra</groupId>
-            <artifactId>cassandra-all</artifactId>
-            <version>${cassandra.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.yaml</groupId>
-                    <artifactId>snakeyaml</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-jackson</artifactId>
             <version>2.10.1-10.0</version>
@@ -81,6 +65,57 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.cassandra</groupId>
+                    <artifactId>cassandra-all</artifactId>
+                    <version>${cassandra.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>commons-codec</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.yaml</groupId>
+                            <artifactId>snakeyaml</artifactId>
+                        </exclusion>
+                    </exclusions>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>dse-db</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.datastax.dse</groupId>
+                    <artifactId>dse-db-all</artifactId>
+                    <version>${cassandra.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>commons-codec</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.yaml</groupId>
+                            <artifactId>snakeyaml</artifactId>
+                        </exclusion>
+                    </exclusions>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <resources>


### PR DESCRIPTION
Additional positional argument is added to make_package.sh.
It allows to override cassandra.version used for compilation.
This allows us to create MCAC tarballs with custom C*.