### PR TITLE
Update ByteBuddy from 1.10.10 to 1.12.19 to support newer mgmt-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <!-- <cassandra.version>4.0-beta4</cassandra.version> -->
         <cassandra.version>3.11.10</cassandra.version>
         <driver.version>3.6.0</driver.version> <!-- Needed for guava 18 compat-->
-        <bytebuddy.version>1.10.10</bytebuddy.version>
+        <bytebuddy.version>1.12.19</bytebuddy.version>
         <mustache.version>0.9.6</mustache.version>
         <collectd.version>0.1.4</collectd.version>
         <docker.java.version>3.1.2</docker.java.version>

--- a/src/main/java/com/datastax/mcac/interceptors/CassandraDaemonInterceptor.java
+++ b/src/main/java/com/datastax/mcac/interceptors/CassandraDaemonInterceptor.java
@@ -2,6 +2,7 @@ package com.datastax.mcac.interceptors;
 
 import java.lang.management.ManagementFactory;
 import java.nio.charset.Charset;
+import java.security.ProtectionDomain;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -42,7 +43,7 @@ public class CassandraDaemonInterceptor extends AbstractInterceptor
         return new AgentBuilder.Transformer()
         {
             @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule)
+            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule, ProtectionDomain protectionDomain)
             {
                 return builder.method(ElementMatchers.named("start")).intercept(MethodDelegation.to(CassandraDaemonInterceptor.class));
             }


### PR DESCRIPTION
This is to support simultaneously the new MCAC replacement in management-api as well as old-MCAC.