### PR TITLE
DSP-23764 update collectd to version 0.1.7 with Python disabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <driver.version>3.6.0</driver.version> <!-- Needed for guava 18 compat-->
         <bytebuddy.version>1.12.19</bytebuddy.version>
         <mustache.version>0.9.6</mustache.version>
-        <collectd.version>0.1.7-rc</collectd.version> <!-- from riptano/collectd -->       
+        <collectd.version>0.1.7</collectd.version> <!-- from riptano/collectd -->       
         <docker.java.version>3.1.2</docker.java.version>
         <build.version.file>build_version.sh</build.version.file>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <driver.version>3.6.0</driver.version> <!-- Needed for guava 18 compat-->
         <bytebuddy.version>1.12.19</bytebuddy.version>
         <mustache.version>0.9.6</mustache.version>
-        <collectd.version>0.1.4</collectd.version>
+        <collectd.version>0.1.7-rc</collectd.version> <!-- from riptano/collectd -->       
         <docker.java.version>3.1.2</docker.java.version>
         <build.version.file>build_version.sh</build.version.file>
     </properties>


### PR DESCRIPTION
Update to collectd version 0.1.7. Previous versions of collectd attract a lot of CVE due to the Python 2.7 usage.
riptano/collectd version 0.1.7 removes the python plugin and usage of python 2.7. 